### PR TITLE
Revise code for "building" NConvex

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,8 @@ jobs:
         version:
           - '1.4'
           - '1.5'
+          - '1.6'
+          - '~1.7.0-0'
           #- 'nightly'
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,16 +41,14 @@ As mentioned above, `JToric` crucially depends on `NConvex`.  A quick way to sat
 Explicitly, you can reproduce the build process by following the following steps:
 
 1. Start `Julia`
-2. Issue the tollowing two lines of code:
+2. Issue the following code:
 
-    `using GAP`
-    `gap_location = GAP.GAPROOT`
+        using GAP; gap_location = GAP.GAPROOT
 
-2. Remember this path gap_location.
+2. Remember this path `gap_location`.
 3. Exit julia.
 4. `cd $(gap_location)/pkg`
-5. `git clone https://github.com/HereAround/NConvex.git`
-6. `git fetch origin martindevel:martindevel`
+5. `git clone -b martindevel https://github.com/HereAround/NConvex.git`
 
 In `$(gap_location)/pkg` you should now have the development version of `NConvex` which does not depend on `CddInterface` and `NormalizInterface`. Since its version is higher than the distributed `NConvex`, this version should be used by `gap` in `julia`.
 

--- a/deps/JToricBuilder.jl
+++ b/deps/JToricBuilder.jl
@@ -15,55 +15,27 @@ Obtain a development version of NConvex.
 """
 function InstallDevelopmentVersionNConvex()
 
-    # find gap-location
-    gap_location = GAP.GAPROOT
-    
     # add pkg to this path
-    p = splitpath( gap_location )
-    p = replace.( p, "/"=>"")
-    install_path = join( push!( p, "pkg" ), "/" )
-    NConvex_path = join( push!( p, "NConvex" ), "/" )
+    install_path = GAP.Packages.DEFAULT_PKGDIR
+    NConvex_path = joinpath(install_path, "NConvex")
 
     # inform what we are doing
-    @info "Install development version of NConvex to \"" * NConvex_path * "\""
-    
+    @info "Install development version of NConvex to \"$(NConvex_path)\""
+
     # if this directory does exist, delete it
     if isdir( NConvex_path )
-
         # delete existing directory
-        @info "DeleteExistingDirectory \"" * NConvex_path * "\""
+        @info "DeleteExistingDirectory \"$(NConvex_path)\""
         rm( NConvex_path, recursive=true )
-        
     end
-            
+
     # inform
-    @info "Obtaining development version of NConvex into \"" * NConvex_path * "\""
-        
-    # prepare git operations
-    res = GAP.Globals.LoadPackage(julia_to_gap("PackageManager"), false)
-    @assert res
-    git = julia_to_gap("git")
-        
+    @info "Obtaining development version of NConvex into \"$(NConvex_path)\""
+
     # clone
-    command = julia_to_gap( "clone https://github.com/HereAround/NConvex.git" )
-    operation = GAP.Globals.PKGMAN_Exec(julia_to_gap( install_path ), git, command, julia_to_gap(""))
-    if operation.code != 0
-        @warn "Cloning of NConvex failed"
-        return false
-    end
-    @info gap_to_julia(operation.output)
-    
-    # fetch development version
-    command = julia_to_gap( "fetch origin martindevel:martindevel && git checkout martindevel" )
-    operation = GAP.Globals.PKGMAN_Exec(julia_to_gap( NConvex_path ), git, command, julia_to_gap(""))
-    if operation.code != 0
-        @warn "Fetching of development version failed"
-        return false
-    end
-    @info gap_to_julia(operation.output)
-    
+    run(`git clone -b martindevel https://github.com/HereAround/NConvex.git $NConvex_path`)
+
     # signal success
     return true
-    
 end
 export InstallDevelopmentVersionNConvex


### PR DESCRIPTION
Install the package into a more appropriate location (the pkg dir of
GAP.GAPROOT, as well as all the files in there, are ephemeral, and are deleted
and regenerated from scratch each time GAP.jl is precompiled).

Also, don't both going through the GAP Package manager just to invoke `git clone`.
