### PR TITLE
Remove has_no_torusfactor

### DIFF
--- a/src/ToricVarieties.jl
+++ b/src/ToricVarieties.jl
@@ -79,12 +79,6 @@ end
 export has_torusfactor
 
 
-function has_no_torusfactor( v::toric_variety )
-    return GAP.Globals.HasNoTorusfactor( v.GapToricVariety )::Bool
-end
-export has_no_torusfactor
-
-
 function is_orbifold( v::toric_variety )
     return GAP.Globals.IsOrbifold( v.GapToricVariety )::Bool
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,6 @@ using Test
     @test JToric.is_smooth( H5 ) == true
     @test JToric.is_complete( H5 ) == true
     @test JToric.has_torusfactor( H5 ) == false
-    @test JToric.has_no_torusfactor( H5 ) == true
     @test JToric.is_orbifold( H5 ) == true
     @test JToric.is_simplicial( H5 ) == true
     @test JToric.is_isomorphic_to_projective_space( H5 ) == false
@@ -31,7 +30,6 @@ using Test
     @test JToric.is_smooth( P2 ) == true
     @test JToric.is_complete( P2 ) == true
     @test JToric.has_torusfactor( P2 ) == false
-    @test JToric.has_no_torusfactor( P2 ) == true
     @test JToric.is_orbifold( P2 ) == true
     @test JToric.is_simplicial( P2 ) == true
     @test JToric.is_isomorphic_to_projective_space( P2 ) == true
@@ -110,7 +108,6 @@ using Test
     @test JToric.is_smooth( v ) == true
     @test JToric.is_complete( v ) == true
     @test JToric.has_torusfactor( v ) == false
-    @test JToric.has_no_torusfactor( v ) == true
     @test JToric.is_orbifold( v ) == true
     @test JToric.is_simplicial( v ) == true
     @test JToric.is_isomorphic_to_projective_space( v ) == false


### PR DESCRIPTION
It seems to be equivalent to !has_torusfactor?

If there is a difference, then that should be made clear...

CC @micjoswig